### PR TITLE
Bump listen arg to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ find some arbitrary high-numbered port that's unused and bind to that. Afterward
 you can query the actual port that was bound to if you need to use the port number
 elsewhere. However, there are cases where the port 0 trick won't work. For example,
 mysqld takes port 0 to mean "the port configured in my.cnf". Docker can bind your
-containers to port 0, but uses its own implementation to find a free port which 
+containers to port 0, but uses its own implementation to find a free port which
 races and fails in the face of parallelism.
 
 `ephemeral-port-reserve` provides an implementation of the port 0 trick which

--- a/ephemeral_port_reserve.py
+++ b/ephemeral_port_reserve.py
@@ -25,7 +25,9 @@ def reserve(ip=LOCALHOST):
     s = socket()
     s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
     s.bind((ip, 0))
-    s.listen(0)
+
+    # the connect below deadlocks on kernel >= 4.4.0 unless this arg is great than zero
+    s.listen(1)
 
     sockname = s.getsockname()
 


### PR DESCRIPTION
We just found that with Kernel 4.4.0-31-generic, this code deadlocks at the `s2.connect` line on Python 2.7, 3.4, and 3.5 (but not Python 2.6).

Inspecting the system calls, we see that Python 2.6 actually ignores our argument to `listen` and instead passes a `1`:

```c
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
bind(3, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
listen(3, 1)                            = 0
```

However, Python2.7 uses our argument:

```c
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
bind(3, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
listen(3, 0)                            = 0
```

Weird! Turns out Python 2.6 sets a minimum of `1` according to the docs (instead of `0` in newer versions), and maybe a bug in the kernel that has broken this (or a bug that it worked in the first place)?