### PR TITLE
Add a shebang since it's executable

### DIFF
--- a/ephemeral_port_reserve.py
+++ b/ephemeral_port_reserve.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import unicode_literals
 


### PR DESCRIPTION
Had about enough of this:

```
$ ./ephemeral_port_reserve.py
from: can't read /var/mail/__future__
from: can't read /var/mail/__future__
import: unable to open X server `' @ error/import.c/ImportImageCommand/364.
import: unable to open X server `' @ error/import.c/ImportImageCommand/364.
from: can't read /var/mail/socket
from: can't read /var/mail/socket
from: can't read /var/mail/socket
from: can't read /var/mail/socket
./ephemeral_port_reserve.py: 11: ./ephemeral_port_reserve.py: LOCALHOST: not found
./ephemeral_port_reserve.py: 14: ./ephemeral_port_reserve.py: Syntax error: "(" unexpected
```